### PR TITLE
Propertly format 'collection_name' header in table

### DIFF
--- a/web/planning-domains.js
+++ b/web/planning-domains.js
@@ -10,17 +10,18 @@ setTimeout(function(){
 }, 1000);
 
 var headings = {'problem_id': 'ID',
-                'domain_id': 'ID',
-                'collection_id': 'ID',
                 'problem': 'Problem',
                 'lower_bound': 'Lower Bound',
                 'upper_bound': 'Upper Bound',
+                'domain_id': 'ID',
+                'domain_name': 'Domain',
+                'tags': 'Tags',
+                'collection_id': 'ID',
+                'collection_name': 'Collection',
+                'description': 'Description',
                 'max_effective_width': 'Max Width',
                 'hplus': 'H-Plus',
                 'domain': 'Domain',
-                'domain_name': 'Domain',
-                'description': 'Description',
-                'tags': 'Tags',
                 'domain_set': 'Domain Set'
 };
 


### PR DESCRIPTION
### Problem

The `planning-domains.js` javascript library can insert an interactive navigation table. This table's header isn't properly formatted when there is a `collection_name` field

![image](https://user-images.githubusercontent.com/63263642/212417071-49ca2520-e0cf-4212-8554-bcc98f2c2649.png)

### After Fix:

![image](https://user-images.githubusercontent.com/63263642/212416958-ae646be1-0677-4b32-82f9-00545e50c84f.png)
