### PR TITLE
call `response.read()` once in `query()`

### DIFF
--- a/planning_domains_api.py
+++ b/planning_domains_api.py
@@ -55,7 +55,7 @@ def query(qs, qtype="GET", params={}, offline=False, format='/json'):
     if "<pre>Payload Too Large</pre>" in tmp:
         data = { "error": True, "message": "Payload too large."}
     else:
-        data = json.loads(response.read())
+        data = json.loads(tmp)
     conn.close()
 
     return data


### PR DESCRIPTION
response.read() will return `None` on second call, so we shouldn't call it twice

before
```console
>>> import planning_domains_api as a
>>> a.get_domain(8) 
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\rmonk\Documents\code-bases\api-tools\planning_domains_api.py", line 165, in get_domain
    return simple_query("/classical/domain/%d" % did)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\rmonk\Documents\code-bases\api-tools\planning_domains_api.py", line 100, in simple_query
    res = query(qs)
          ^^^^^^^^^
  File "C:\Users\rmonk\Documents\code-bases\api-tools\planning_domains_api.py", line 58, in query
    data = json.loads(response.read())
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\json\__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\json\decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\json\decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

after
```console
>>> import planning_domains_api as a
>>> a.get_domain(8)
{'domain_id': 8, 'domain_name': 'sokoban', 'description': '(sat11) This domain models the Sokoban game. (http://en.wikipedia.org/wiki/Sokoban)', 'tags': '[":adl",":strips",":action-costs",":equality",":typing"]'}
```