### PR TITLE
Create script to update resource tags in DB

### DIFF
--- a/tag_updater.py
+++ b/tag_updater.py
@@ -47,13 +47,6 @@ for collection in collections:
     for domain in domains:
         domain_id = domain['domain_id']
 
-        if domain_id == 80: # This domain 404's could not read parse domain reqs
-            continue
-        if domain_id == 21: # This domain is the settlers domain, and is not classical
-            continue
-        if domain_id == 145 or domain_id == 133: # These domains cannot be parsed with VAl because of the "?after" parsing bug
-            continue
-
         # pull pre-computed domain requirements
         required_tags = processed_requirements[str(domain_id)]['val']
 

--- a/tag_updater.py
+++ b/tag_updater.py
@@ -62,4 +62,4 @@ for collection in collections:
             update_tags("problem", problem['problem_id'], current=problem_current_tags, required=required_tags)
 
     collection_current_tags = ast.literal_eval(collection['tags'])
-    update_tags("domain", domain_id, current=collection_current_tags, required=list(collection_required_tags))
+    update_tags("collection", collection_id, current=collection_current_tags, required=list(collection_required_tags))

--- a/tag_updater.py
+++ b/tag_updater.py
@@ -1,0 +1,65 @@
+import json
+import planning_domains_api as api
+import ast
+
+# Pull requirments from precomputed json file
+f = open("processed_result5.json")
+processed_requirements = json.load(f)
+
+DEBUG = True
+
+def update_tags(resource, id, *, current, required):
+    assert resource in ["collection", "domain", "problem"]   
+
+    # Remove incorrect tags
+    for tag in current:
+        if tag not in required:
+            if DEBUG:
+                print(f"Untagging {tag} from {resource}: {id}")
+            elif resource == "collection":
+                api.untag_collection(id, tag)
+            elif resource == "domain":
+                api.untag_domain(id, tag)
+            elif resource == "problem":
+                api.untag_problem(id, tag)
+
+    # Add required tags
+    for tag in required:
+        if tag not in current:
+            if DEBUG:
+                print(f"Tagging {tag} from {resource}: {id}")
+            elif resource == "collection":
+                api.tag_collection(id, tag)
+            elif resource == "domain":
+                api.tag_domain(id, tag)
+            elif resource == "problem":
+                api.tag_problem(id, tag)
+
+collections = api.get_collections()
+for collection in collections:
+    collection_id = int(collection["collection_id"])
+
+    # Keep track of all requirements inside this collection
+    collection_required_tags = set()
+
+    domains = api.get_domains(collection_id)
+    assert ast.literal_eval(collection['domain_set']).sort() == [x['domain_id'] for x in domains].sort(), "domain_set property should contain all domains"
+    for domain in domains:
+        domain_id = domain['domain_id']
+
+        # pull pre-computed domain requirements
+        required_tags = processed_requirements[str(domain_id)]['val']
+
+        domain_current_tags = ast.literal_eval(domain['tags'])
+        update_tags("domain", domain_id, current=domain_current_tags, required=required_tags)
+
+        # Update collection_required_tags with the union of itself and this domain's requirements
+        collection_required_tags.update(required_tags)
+
+        problems = api.get_problems(domain_id)
+        for problem in problems:
+            problem_current_tags = ast.literal_eval(problem['tags'])
+            update_tags("problem", problem['problem_id'], current=problem_current_tags, required=required_tags)
+
+    collection_current_tags = ast.literal_eval(collection['tags'])
+    update_tags("domain", domain_id, current=collection_current_tags, required=list(collection_required_tags))

--- a/tag_updater.py
+++ b/tag_updater.py
@@ -47,6 +47,13 @@ for collection in collections:
     for domain in domains:
         domain_id = domain['domain_id']
 
+        if domain_id == 80: # This domain 404's could not read parse domain reqs
+            continue
+        if domain_id == 21: # This domain is the settlers domain, and is not classical
+            continue
+        if domain_id == 145 or domain_id == 133: # These domains cannot be parsed with VAl because of the "?after" parsing bug
+            continue
+
         # pull pre-computed domain requirements
         required_tags = processed_requirements[str(domain_id)]['val']
 


### PR DESCRIPTION
Uses the `planning_domains_api` to update the tags. An authorized user needs to run the script to make tag changes

Here is the file that contains the requirement data: (This is the file I used to update the classical-domains repo) (github doesn't allow `.json` attachements so I made it a `.txt`)

[processed_result5.txt](https://github.com/AI-Planning/api-tools/files/11093470/processed_result5.txt)
